### PR TITLE
Clean up the intermediate objects to avoid warning

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -16,7 +16,7 @@ CARGOTMP = $(CURDIR)/rust/.cargo
 CARGO_BUILD_ARGS = -j 2 --lib --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 RUST_BACKTRACE=1
 
-all: $(SHLIB)
+all: $(SHLIB) clean_intermediate
 
 $(SHLIB): $(STATLIB)
 
@@ -51,9 +51,10 @@ $(STATLIB):
 	rm -Rf $(VENDOR_DIR)
 	rm -Rf $(LIBDIR)/build
 
-C_clean:
-	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
+clean_intermediate:
+	rm -f $(STATLIB)
 
 clean:
-	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
+	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/target
 
+.PHONY: all clean_intermediate clean

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -16,7 +16,7 @@ CARGOTMP = $(CURDIR)/rust/.cargo
 # to overwrite it via configuration.
 CARGO_LINKER = x86_64-w64-mingw32.static.posix-gcc.exe
 
-all: C_clean
+all: $(SHLIB) clean_intermediate
 
 $(SHLIB): $(STATLIB)
 
@@ -36,8 +36,10 @@ $(STATLIB):
 	rm -Rf $(VENDOR_DIR)
 	rm -Rf $(LIBDIR)/build
 
-C_clean:
-	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
+clean_intermediate:
+	rm -f $(STATLIB)
 
 clean:
-	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
+	rm -Rf $(SHLIB) $(OBJECTS) $(STATLIB) ./rust/target
+
+.PHONY: all clean_intermediate clean


### PR DESCRIPTION
From some days ago, `R CMD check` checks the compiled code in the sub-directories and it gives this warning. I believe this is false positive. `rust/target/release/libclarabel.a` is not necessary after generating `SHLIB`. However, with the current `Makevars.*`, it doesn't get cleaned up at the time of the check.

This pull request moves the clean up earlier by making it the subsequent step to `$(SHLIB)`.

https://cran.r-project.org/web/checks/check_results_clarabel.html

```
  File ‘clarabel/libs/clarabel.so’:
    Found ‘_exit’, possibly from ‘_exit’ (C)
      Object: ‘rust/target/release/libclarabel.a’
    Found ‘abort’, possibly from ‘abort’ (C)
      Object: ‘rust/target/release/libclarabel.a’
    Found ‘exit’, possibly from ‘exit’ (C)
      Object: ‘rust/target/release/libclarabel.a’
  
  Compiled code should not call entry points which might terminate R nor
  write to stdout/stderr instead of to the console, nor use Fortran I/O
  nor system RNGs nor [v]sprintf.
  
  See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual
```

More details can be found:

- https://github.com/yutannihilation/savvy/issues/355
- https://github.com/yutannihilation/savvy/pull/357