### PR TITLE
Make sure `clean_intermediate` is executed after `$(SHLIB)` is created

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -51,7 +51,7 @@ $(STATLIB):
 	rm -Rf $(VENDOR_DIR)
 	rm -Rf $(LIBDIR)/build
 
-clean_intermediate:
+clean_intermediate: $(SHLIB)
 	rm -f $(STATLIB)
 
 clean:

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -36,7 +36,7 @@ $(STATLIB):
 	rm -Rf $(VENDOR_DIR)
 	rm -Rf $(LIBDIR)/build
 
-clean_intermediate:
+clean_intermediate: $(SHLIB)
 	rm -f $(STATLIB)
 
 clean:


### PR DESCRIPTION
A followup of #17 

In #17, I naively assumed this will make the execution order to that `$(SHLIB)` first and then `clean_intermediate`. 

```make
all: $(SHLIB) clean_intermediate
```

However, it's not always the case; when `make` is executed in parallel, `clean_intermediate` can be done before `$(SHLIB)`, which means the intermediates of `$(SHLIB)` (thus `$(STATLIB)`) are not cleaned up.

This pull request is to ensure the order by defining a dependency between `clean_intermediate` and `$(SHLIB)`.